### PR TITLE
Select extent by current canvas extent or drawing a rectangle

### DIFF
--- a/controllers/extent_selector.py
+++ b/controllers/extent_selector.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import re
 
 from PyQt5 import uic
@@ -9,7 +8,7 @@ import qgis.utils
 
 from qgis.core import (
     QgsProject, QgsMapLayerProxyModel, QgsRectangle, QgsReferencedRectangle,
-    QgsPointXY, QgsMapLayer, QgsCoordinateReferenceSystem)
+    QgsPointXY, QgsCoordinateReferenceSystem)
 from qgis.gui import QgsMapLayerComboBox
 from processing.gui.RectangleMapTool import RectangleMapTool
 
@@ -27,7 +26,7 @@ class ExtentSelector(QWidget, FORM_CLASS):
 
     EXTRACT_REGEX = r'(-?\d+(\.\d+)?) (-?\d+(\.\d+)?), (-?\d+(\.\d+)?) (-?\d+(\.\d+)?) \[(EPSG:(\d{2,}))\]'
 
-    def __init__(self, parent=None, iface=None, filters=None) -> None:
+    def __init__(self, parent=None, iface=None, filters=None):
         """Constructor."""
         super(ExtentSelector, self).__init__(parent)
 
@@ -68,7 +67,7 @@ class ExtentSelector(QWidget, FORM_CLASS):
             self.on_extent_layer_dialog_accepted)
         self.lineEdit.textChanged.connect(self.on_line_textchanged)
 
-    def _init_extent_layer_dialog(self, filters: QgsMapLayerProxyModel.Filters = QgsMapLayerProxyModel.All) -> QDialog:
+    def _init_extent_layer_dialog(self, filters=QgsMapLayerProxyModel.All):
         dialog = QDialog()
         layout = QVBoxLayout()
         buttons = QDialogButtonBox(
@@ -92,7 +91,7 @@ class ExtentSelector(QWidget, FORM_CLASS):
 
         return dialog
 
-    def is_valid(self, value: str = None) -> bool:
+    def is_valid(self, value=None):
         """Check if input string is valid."""
         if value is None:
             value = self.lineEdit.text()
@@ -102,7 +101,7 @@ class ExtentSelector(QWidget, FORM_CLASS):
         else:
             return False
 
-    def value(self) -> Optional[QgsReferencedRectangle]:
+    def value(self):
         """Mimic the QT API to get the value."""
         # Even though it is more work, everytime we should convert the
         # rectangle to string and then parse the string back to a rectangle.
@@ -125,7 +124,7 @@ class ExtentSelector(QWidget, FORM_CLASS):
 
         return rect
 
-    def toggle_line_validity(self, is_valid: bool = None) -> None:
+    def toggle_line_validity(self, is_valid=None):
         """Set the input with red class if not valid."""
         if is_valid is None:
             is_valid = self.is_valid()
@@ -135,30 +134,30 @@ class ExtentSelector(QWidget, FORM_CLASS):
         else:
             self.lineEdit.setStyleSheet('color: red;')
 
-    def on_line_textchanged(self, value: str) -> None:
+    def on_line_textchanged(self, value):
         """Triggered when the input changes, even programatically."""
         self.toggle_line_validity()
 
-    def on_extent_layer_dialog_accepted(self) -> None:
+    def on_extent_layer_dialog_accepted(self):
         """Triggered when a layer is selected and dialog accepted."""
         layer = self.extent_layer_dialog.layer_combobox.currentLayer()
         self.set_value_from_layer(layer)
 
-    def on_action_canvas_triggered(self) -> None:
+    def on_action_canvas_triggered(self):
         """Triggered when menu action "canvas" is clicked."""
         self.set_value_from_rect(self.canvas.extent())
 
-    def on_action_layer_triggered(self, filters: QgsMapLayerProxyModel.Filters) -> None:
+    def on_action_layer_triggered(self, filters):
         """Triggered when menu action "layer" is clicked."""
         self.extent_layer_dialog.show()
 
-    def on_action_selection_triggered(self) -> None:
+    def on_action_selection_triggered(self):
         """Triggered when menu action "selection" is clicked."""
         self.prev_map_tool = self.canvas.mapTool()
         self.canvas.setMapTool(self.tool)
         self.dialog.showMinimized()
 
-    def on_tool_update_extent(self) -> None:
+    def on_tool_update_extent(self):
         """Triggered when the map tool finishes drawing a rectangle."""
         rect = self.tool.rectangle()
         self.set_value_from_rect(rect)
@@ -170,7 +169,7 @@ class ExtentSelector(QWidget, FORM_CLASS):
         self.dialog.raise_()
         self.dialog.activateWindow()
 
-    def set_value_from_str(self, value: str, crs: QgsCoordinateReferenceSystem = None) -> None:
+    def set_value_from_str(self, value, crs=None):
         """Set the coordinates from the coordinates string.
 
         If no CRS provided, gets the one from the project.
@@ -185,11 +184,11 @@ class ExtentSelector(QWidget, FORM_CLASS):
         self.toggle_line_validity()
         self.lineEdit.setText(value)
 
-    def set_value_from_layer(self, layer: QgsMapLayer) -> None:
+    def set_value_from_layer(self, layer):
         """Set the coordinates to the passed layer extent."""
         self.set_value_from_rect(layer.extent(), layer.crs())
 
-    def set_value_from_rect(self, rect: QgsRectangle, crs: QgsCoordinateReferenceSystem = None) -> None:
+    def set_value_from_rect(self, rect, crs=None):
         """Set the coordinates from the passed rectangle extent.
 
         If no CRS provided, tries to obtain it from the rectangle.

--- a/controllers/extent_selector.py
+++ b/controllers/extent_selector.py
@@ -1,0 +1,200 @@
+from typing import Optional
+import re
+
+from PyQt5 import uic
+from PyQt5.QtWidgets import (
+    QWidget, QAction, QMenu, QVBoxLayout, QDialog, QDialogButtonBox)
+
+import qgis.utils
+
+from qgis.core import (
+    QgsProject, QgsMapLayerProxyModel, QgsRectangle, QgsReferencedRectangle,
+    QgsPointXY, QgsMapLayer, QgsCoordinateReferenceSystem)
+from qgis.gui import QgsMapLayerComboBox
+from processing.gui.RectangleMapTool import RectangleMapTool
+
+from ..utils import ui
+
+
+FORM_CLASS, _ = uic.loadUiType(ui.path('extent_selector.ui'))
+
+
+class ExtentSelector(QWidget, FORM_CLASS):
+    """Helper widget to provide extent selection functionality.
+
+    Mimics the UI behaviour of the qgis.processing.gui.ExtentSelectionPanel
+    """
+
+    EXTRACT_REGEX = r'(-?\d+(\.\d+)?) (-?\d+(\.\d+)?), (-?\d+(\.\d+)?) (-?\d+(\.\d+)?) \[(EPSG:(\d{2,}))\]'
+
+    def __init__(self, parent=None, iface=None, filters=None) -> None:
+        """Constructor."""
+        super(ExtentSelector, self).__init__(parent)
+
+        self.setupUi(self)
+
+        # self.dialog is used by RectangleMapTool!!!
+        self.dialog = parent
+        self.iface = iface if iface else qgis.utils.iface
+        self.canvas = iface.mapCanvas()
+        self.prev_map_tool = self.canvas.mapTool()
+        self.tool = RectangleMapTool(self.canvas)
+
+        self.tool.rectangleCreated.connect(self.on_tool_update_extent)
+
+        self.actionCanvas = QAction('Use canvas extent', self.menuButton)
+        self.actionLayer = QAction('Use layer extent', self.menuButton)
+        self.actionSelection = QAction('Draw extent...', self.menuButton)
+
+        self.actionCanvas.setToolTip('')
+        self.actionLayer.setToolTip('')
+        self.actionSelection.setToolTip('')
+
+        self.menu = QMenu()
+        self.menu.addAction(self.actionCanvas)
+        self.menu.addAction(self.actionLayer)
+        self.menu.addSeparator()
+        self.menu.addAction(self.actionSelection)
+
+        self.menuButton.setMenu(self.menu)
+
+        self.extent_layer_dialog = self._init_extent_layer_dialog()
+
+        self.actionCanvas.triggered.connect(self.on_action_canvas_triggered)
+        self.actionLayer.triggered.connect(self.on_action_layer_triggered)
+        self.actionSelection.triggered.connect(
+            self.on_action_selection_triggered)
+        self.extent_layer_dialog.accepted.connect(
+            self.on_extent_layer_dialog_accepted)
+        self.lineEdit.textChanged.connect(self.on_line_textchanged)
+
+    def _init_extent_layer_dialog(self, filters: QgsMapLayerProxyModel.Filters = QgsMapLayerProxyModel.All) -> QDialog:
+        dialog = QDialog()
+        layout = QVBoxLayout()
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, dialog)
+        layer_combobox = QgsMapLayerComboBox()
+
+        layout.addWidget(layer_combobox)
+        layout.addWidget(buttons)
+
+        layer_combobox.setFilters(filters)
+        layer_combobox.setAccessibleName('')
+        dialog.setModal(True)
+        dialog.setLayout(layout)
+
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+
+        # ugly, but better to keep the function as pure as possible pure.
+        # I guess it begs for it's own class
+        dialog.layer_combobox = layer_combobox
+
+        return dialog
+
+    def is_valid(self, value: str = None) -> bool:
+        """Check if input string is valid."""
+        if value is None:
+            value = self.lineEdit.text()
+
+        if re.match(self.EXTRACT_REGEX, value):
+            return True
+        else:
+            return False
+
+    def value(self) -> Optional[QgsReferencedRectangle]:
+        """Mimic the QT API to get the value."""
+        # Even though it is more work, everytime we should convert the
+        # rectangle to string and then parse the string back to a rectangle.
+        # This way there is only single source of
+        # truth and will keep away a lot of tricky bugs
+
+        value = self.lineEdit.text().strip()
+
+        if not self.is_valid(value):
+            return None
+
+        [x1, _, y1, _, x2, _, y2, _, epsg, crs_code] = re.findall(
+            self.EXTRACT_REGEX, value)[0]
+
+        p1 = QgsPointXY(float(x1), float(y1))
+        p2 = QgsPointXY(float(x2), float(y2))
+        rect = QgsReferencedRectangle(
+            QgsRectangle(p1, p2),
+            QgsCoordinateReferenceSystem(int(crs_code)))
+
+        return rect
+
+    def toggle_line_validity(self, is_valid: bool = None) -> None:
+        """Set the input with red class if not valid."""
+        if is_valid is None:
+            is_valid = self.is_valid()
+
+        if is_valid:
+            self.lineEdit.setStyleSheet('color: inherit;')
+        else:
+            self.lineEdit.setStyleSheet('color: red;')
+
+    def on_line_textchanged(self, value: str) -> None:
+        """Triggered when the input changes, even programatically."""
+        self.toggle_line_validity()
+
+    def on_extent_layer_dialog_accepted(self) -> None:
+        """Triggered when a layer is selected and dialog accepted."""
+        layer = self.extent_layer_dialog.layer_combobox.currentLayer()
+        self.set_value_from_layer(layer)
+
+    def on_action_canvas_triggered(self) -> None:
+        """Triggered when menu action "canvas" is clicked."""
+        self.set_value_from_rect(self.canvas.extent())
+
+    def on_action_layer_triggered(self, filters: QgsMapLayerProxyModel.Filters) -> None:
+        """Triggered when menu action "layer" is clicked."""
+        self.extent_layer_dialog.show()
+
+    def on_action_selection_triggered(self) -> None:
+        """Triggered when menu action "selection" is clicked."""
+        self.prev_map_tool = self.canvas.mapTool()
+        self.canvas.setMapTool(self.tool)
+        self.dialog.showMinimized()
+
+    def on_tool_update_extent(self) -> None:
+        """Triggered when the map tool finishes drawing a rectangle."""
+        rect = self.tool.rectangle()
+        self.set_value_from_rect(rect)
+
+        self.tool.reset()
+
+        self.canvas.setMapTool(self.prev_map_tool)
+        self.dialog.showNormal()
+        self.dialog.raise_()
+        self.dialog.activateWindow()
+
+    def set_value_from_str(self, value: str, crs: QgsCoordinateReferenceSystem = None) -> None:
+        """Set the coordinates from the coordinates string.
+
+        If no CRS provided, gets the one from the project.
+        There should be no CRS in the string!
+        """
+        # don't cache current project, as it may be changed
+        crs = QgsProject.instance().crs() if not crs else crs
+
+        if crs.isValid():
+            value += ' [' + crs.authid() + ']'
+
+        self.toggle_line_validity()
+        self.lineEdit.setText(value)
+
+    def set_value_from_layer(self, layer: QgsMapLayer) -> None:
+        """Set the coordinates to the passed layer extent."""
+        self.set_value_from_rect(layer.extent(), layer.crs())
+
+    def set_value_from_rect(self, rect: QgsRectangle, crs: QgsCoordinateReferenceSystem = None) -> None:
+        """Set the coordinates from the passed rectangle extent.
+
+        If no CRS provided, tries to obtain it from the rectangle.
+        """
+        value = rect.asWktCoordinates()
+        crs = rect.crs() if isinstance(rect, QgsReferencedRectangle) else crs
+
+        self.set_value_from_str(value, crs)

--- a/controllers/results_dialog.py
+++ b/controllers/results_dialog.py
@@ -6,8 +6,7 @@ from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices, QColor
 
 from qgis.gui import QgsRubberBand
-from qgis.core import (QgsWkbTypes, QgsPointXY, QgsGeometry,
-    QgsReferencedRectangle)
+from qgis.core import (QgsWkbTypes, QgsPointXY, QgsGeometry, QgsReferencedRectangle)
 
 from ..utils import ui
 from ..utils import crs

--- a/stac_browser.py
+++ b/stac_browser.py
@@ -72,7 +72,7 @@ class STACBrowser:
             },
         }
 
-    def on_search(self, api_collections, extent_layer, time_period, query):
+    def on_search(self, api_collections, extent_rect, time_period, query):
         (start_time, end_time) = time_period
 
         # the API consumes only EPSG:4326

--- a/stac_browser.py
+++ b/stac_browser.py
@@ -5,8 +5,6 @@ import sys
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QAction
 
-from qgis.core import (QgsCoordinateTransform, QgsCoordinateReferenceSystem,
-                       QgsProject)
 from .resources import *
 from .controllers.collection_loading_dialog import CollectionLoadingDialog
 from .controllers.query_dialog import QueryDialog
@@ -18,6 +16,7 @@ from .controllers.configure_apis_dialog import ConfigureAPIDialog
 from .controllers.about_dialog import AboutDialog
 from .utils.config import Config
 from .utils.logging import error
+from .utils import crs
 
 
 class STACBrowser:
@@ -77,14 +76,7 @@ class STACBrowser:
         (start_time, end_time) = time_period
 
         # the API consumes only EPSG:4326
-        transform = QgsCoordinateTransform(
-            extent_rect.crs(),
-            QgsCoordinateReferenceSystem(4326),
-            QgsProject.instance())
-
-        assert transform.isValid()
-
-        extent_rect = transform.transform(extent_rect)
+        extent_rect = crs.transform(extent_rect.crs(), 4326, extent_rect)
 
         extent = [
             extent_rect.xMinimum(),

--- a/stac_browser.py
+++ b/stac_browser.py
@@ -5,6 +5,8 @@ import sys
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QAction
 
+from qgis.core import (QgsCoordinateTransform, QgsCoordinateReferenceSystem,
+                       QgsProject)
 from .resources import *
 from .controllers.collection_loading_dialog import CollectionLoadingDialog
 from .controllers.query_dialog import QueryDialog
@@ -71,10 +73,19 @@ class STACBrowser:
             },
         }
 
-    def on_search(self, api_collections, extent_layer, time_period):
+    def on_search(self, api_collections, extent_rect, time_period):
         (start_time, end_time) = time_period
 
-        extent_rect = extent_layer.extent()
+        # the API consumes only EPSG:4326
+        transform = QgsCoordinateTransform(
+            extent_rect.crs(),
+            QgsCoordinateReferenceSystem(4326),
+            QgsProject.instance())
+
+        assert transform.isValid()
+
+        extent_rect = transform.transform(extent_rect)
+
         extent = [
             extent_rect.xMinimum(),
             extent_rect.yMinimum(),

--- a/views/extent_selector.ui
+++ b/views/extent_selector.ui
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExtentSelector</class>
+ <widget class="QWidget" name="ExtentSelector">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>248</width>
+    <height>50</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="lineEdit"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="menuButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>30</width>
+         <height>30</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/views/query_dialog.ui
+++ b/views/query_dialog.ui
@@ -71,7 +71,7 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <layout class="QFormLayout" name="formLayout_2">
+        <layout class="QFormLayout" name="filterLayout">
          <item row="0" column="0">
           <widget class="QLabel" name="extentLabel">
            <property name="text">
@@ -109,9 +109,6 @@
             <string>yyyy-MM-dd HH:mmZ</string>
            </property>
           </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QgsMapLayerComboBox" name="extentLayer"/>
          </item>
         </layout>
        </item>
@@ -167,13 +164,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsmaplayercombobox.h</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/views/query_dialog.ui
+++ b/views/query_dialog.ui
@@ -173,6 +173,16 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="enableFiltersCheckBox">
+           <property name="text">
+            <string>Enable cloud cover filter</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>


### PR DESCRIPTION
Fixes #59 . It's a bit confusing with the two snake_ and camelCase conventions in the same project. I'm trying to follow your style, not sure if I manage all the time.

The new extent selector is similar to qgis.processing.gui.ExtentSelectionPanel. Actually I reuse some code from there, however, it's impossible to fully utilize it (depends on processing too much).

Also fixed a bug, that I didn't notice the previous time. As far as I see, the protocol only accepts bbox in geographic coordinates (I didn't find it in the spec, I'll open an issue about this). However, if the layer is in any other CRS, the search fails. I fixed it now.

Another change is that I use [PEP484](https://www.python.org/dev/peps/pep-0484/). I would suggest to use it everywhere in the project, it just makes it easier to develop, including for newcomers.