### PR TITLE
Including CBERS4 on AWS STAC server

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -50,6 +50,10 @@ class Config:
                 {
                     "id": "default-astraea",
                     "href": "https://stac.astraea.earth/api/v2",
+                },
+                {
+                    "id": "default-cbers",
+                    "href": "https://stac.amskepler.com/v07",
                 }
             ]
 


### PR DESCRIPTION
Checked compatibility for searching up to selecting scene and viewing metadata, works fine. Cloud filter needs to be disabled for returning results, CBERS data does not currently include cloud coverage information.

Downloading does not currently works since the data is in a 'requester pays' bucket, same as sentinel on AWS.

Fell free to report any issues on STAC implementation [here](https://github.com/fredliporace/cbers-2-stac)